### PR TITLE
Substitutes a forked repo for mybinder PDSH link

### DIFF
--- a/_extras/guide.md
+++ b/_extras/guide.md
@@ -1,0 +1,11 @@
+---
+layout: page
+title: "Instructor Notes"
+permalink: /guide/
+---
+
+## Introduction to Binder
+
+Note that there's a problem with launching the Python Data Science Handbook repo on Mybinder, due to an incompatibility between the required version of the scikit-image dependency and the default Python runtime on Mybinder.
+
+This has been temporarily fixed in [#8](https://github.com/Reproducible-Science-Curriculum/sharing-RR-Jupyter/pull/8). If learners notice the inconstistency between the Github URL and the Mybinder.org URL, you can explain this.

--- a/slides/02-intro_to_binder.ipynb
+++ b/slides/02-intro_to_binder.ipynb
@@ -136,7 +136,9 @@
    "source": [
     "Here's an example of a Binder link:\n",
     "\n",
-    "https://mybinder.org/v2/gh/jakevdp/PythonDataScienceHandbook/master?filepath=notebooks%2FIndex.ipynb\n",
+    "<!-- https://mybinder.org/v2/gh/jakevdp/PythonDataScienceHandbook/master?filepath=notebooks%2FIndex.ipynb -->\n",
+    "<!-- The original is currently broken, therefore using a fork that has the necessary Python 3.5 runtime specified. Consider switching to another repo. -->\n",
+    "https://mybinder.org/v2/gh/baldwint/PythonDataScienceHandbook/py35\n",
     "\n",
     "Clicking it will create a *live* version of Jake van der Plas' Datascience Handbook repository:\n",
     "\n",

--- a/slides/02-intro_to_binder.slides.html
+++ b/slides/02-intro_to_binder.slides.html
@@ -11992,7 +11992,9 @@ a.anchor-link {
 <div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <p>Here's an example of a Binder link:</p>
-<p><a href="https://mybinder.org/v2/gh/jakevdp/PythonDataScienceHandbook/master?filepath=notebooks%2FIndex.ipynb">https://mybinder.org/v2/gh/jakevdp/PythonDataScienceHandbook/master?filepath=notebooks%2FIndex.ipynb</a></p>
+<p><!-- https://mybinder.org/v2/gh/jakevdp/PythonDataScienceHandbook/master?filepath=notebooks%2FIndex.ipynb -->
+<!-- The original is currently broken, therefore using a fork that has the necessary Python 3.5 runtime specified. Consider switching to another repo. -->
+<a href="https://mybinder.org/v2/gh/baldwint/PythonDataScienceHandbook/py35">https://mybinder.org/v2/gh/baldwint/PythonDataScienceHandbook/py35</a></p>
 <p>Clicking it will create a <em>live</em> version of Jake van der Plas' Datascience Handbook repository:</p>
 <p><a href="https://github.com/jakevdp/PythonDataScienceHandbook">https://github.com/jakevdp/PythonDataScienceHandbook</a></p>
 


### PR DESCRIPTION
The Mybinder.org link for Jake van der Plas' Python Data Science Handbook (PDSH) is currently broken (and has been for a while: jakevdp/PythonDataScienceHandbook#108). The root of the problem is an incompatibility between the version of scikit-image stated in the requirements.txt and the 3.6+ version of Python. Upgrading the scikit-image requirement has been stalled for > 6 months (see jakevdp/PythonDataScienceHandbook#117). The alternative is to force the Python runtime to Python 3.5, which is what one fork did: baldwint/PythonDataScienceHandbook@b23349050e2eaeefabedcfad753d00f8c89903d3

Here we're commenting out the link that we'd really want but that's broken (bad for learners), and instead use the link that uses the aforementioned fork.

This obviously has to be a temporary fix only. Currently there is no sign that the problem will be fixed in the original repo by merging jakevdp/PythonDataScienceHandbook#117. One more long-term reliable solution to this could be to fork the original repo here and apply the same (trivial) fix as in the aforementioned fork. Alternatively, we may consider switching to another example.
