### PR TITLE
Substitutes the Data Exploration notebook for mybinder PDSH link

### DIFF
--- a/slides/02-intro_to_binder.ipynb
+++ b/slides/02-intro_to_binder.ipynb
@@ -136,11 +136,11 @@
    "source": [
     "Here's an example of a Binder link:\n",
     "\n",
-    "https://mybinder.org/v2/gh/jakevdp/PythonDataScienceHandbook/master?filepath=notebooks%2FIndex.ipynb\n",
+    "https://mybinder.org/v2/gh/Reproducible-Science-Curriculum/data-exploration-RR-Jupyter/gh-pages?filepath=notebooks%2FData_exploration_run.ipynb\n",
     "\n",
-    "Clicking it will create a *live* version of Jake van der Plas' Datascience Handbook repository:\n",
+    "Clicking it will create a *live* version of the Data Exploration notebook from the earlier lesson, which is maintained in this GitHub repository:\n",
     "\n",
-    "https://github.com/jakevdp/PythonDataScienceHandbook"
+    "https://github.com/Reproducible-Science-Curriculum/data-exploration-RR-Jupyter\n"
    ]
   },
   {

--- a/slides/02-intro_to_binder.slides.html
+++ b/slides/02-intro_to_binder.slides.html
@@ -11992,9 +11992,9 @@ a.anchor-link {
 <div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <p>Here's an example of a Binder link:</p>
-<p><a href="https://mybinder.org/v2/gh/jakevdp/PythonDataScienceHandbook/master?filepath=notebooks%2FIndex.ipynb">https://mybinder.org/v2/gh/jakevdp/PythonDataScienceHandbook/master?filepath=notebooks%2FIndex.ipynb</a></p>
-<p>Clicking it will create a <em>live</em> version of Jake van der Plas' Datascience Handbook repository:</p>
-<p><a href="https://github.com/jakevdp/PythonDataScienceHandbook">https://github.com/jakevdp/PythonDataScienceHandbook</a></p>
+<p><a href="https://mybinder.org/v2/gh/Reproducible-Science-Curriculum/data-exploration-RR-Jupyter/gh-pages?filepath=notebooks%2FData_exploration_run.ipynb">https://mybinder.org/v2/gh/Reproducible-Science-Curriculum/data-exploration-RR-Jupyter/gh-pages?filepath=notebooks%2FData_exploration_run.ipynb</a></p>
+<p>Clicking it will create a <em>live</em> version of the Data Exploration notebook from the earlier lesson, which is maintained in this GitHub repository:</p>
+<p><a href="https://github.com/Reproducible-Science-Curriculum/data-exploration-RR-Jupyter">https://github.com/Reproducible-Science-Curriculum/data-exploration-RR-Jupyter</a></p>
 
 </div>
 </div>


### PR DESCRIPTION
The Mybinder.org link for Jake van der Plas' Python Data Science Handbook (PDSH) is currently broken (and has been for a while: jakevdp/PythonDataScienceHandbook#108). The root of the problem is an incompatibility between the version of scikit-image stated in the requirements.txt and the 3.6+ version of Python. Upgrading the scikit-image requirement has been stalled for > 6 months (see jakevdp/PythonDataScienceHandbook#117). The alternative is to force the Python runtime to Python 3.5, which is what one fork did: baldwint/PythonDataScienceHandbook@b23349050e2eaeefabedcfad753d00f8c89903d3

We could switch to this fork, but this obviously would have to be a temporary fix only, and would almost be guaranteed to break again in the future. Currently there is no sign that the problem will be fixed in the original repo by merging jakevdp/PythonDataScienceHandbook#117.

So instead of using a temporary fix and/or waiting for whenever the original repo will be fixed, this proposal switches to a notebooke "of our own", which has the advantages of having only few and relatively common dependencies, and being one that the learners just worked through, and now get to see a live-shared version of.

This is mutually exclusive with and an alternative to #8.
